### PR TITLE
Use spectral type code instead SpT string

### DIFF
--- a/sedsimple.py
+++ b/sedsimple.py
@@ -109,7 +109,7 @@ class SEDSIMPLE(SED):
             for row in self.inventory[table]:
                 if row['adopted']:
                     bibcode = self._fetch_db_bibcode(row['reference'])
-                    self.spectral_type = row['spectral_type_string'], bibcode
+                    self.spectral_type = row['spectral_type_code'], bibcode
         else:
             self.message(f"No spectral type for {self.name} in database.", pre='[SIMPLE]')
 


### PR DESCRIPTION
Changing the load_spt function to use the spt code instead of the string since this trips up with a spt of something like L7 VL-G. Using the string can give an error if sedkit doesn't not parse through it correctly, so to bypass this problem, it will be better to just use the spectral_type_code. 